### PR TITLE
Avoid downloading plugins.json

### DIFF
--- a/src/main/java/ro/fortsoft/pf4j/update/UpdateRepository.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/UpdateRepository.java
@@ -79,7 +79,7 @@ public class UpdateRepository {
     private void initPlugins() {
         Reader pluginsJsonReader;
         try {
-            URL pluginsUrl = (new URI(url)).resolve(pluginsJson).toURL();
+            URL pluginsUrl = new URL(new URL(url), pluginsJson);
             log.debug("Read plugins of '{}' repository from '{}'", id, pluginsUrl);
             pluginsJsonReader = new InputStreamReader(pluginsUrl.openStream());
         } catch (Exception e) {

--- a/src/main/java/ro/fortsoft/pf4j/update/UpdateRepository.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/UpdateRepository.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.Serializable;
-import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
@@ -38,7 +37,7 @@ public class UpdateRepository {
 
     private static final Logger log = LoggerFactory.getLogger(UpdateRepository.class);
 
-    private static final String pluginsJson = "plugins.json";
+    private static final String DEFAULT_PLUGINS_JSON = "plugins.json";
 
     private String id;
     private String url;
@@ -79,7 +78,7 @@ public class UpdateRepository {
     private void initPlugins() {
         Reader pluginsJsonReader;
         try {
-            URL pluginsUrl = new URL(new URL(url), pluginsJson);
+            URL pluginsUrl = new URL(new URL(url), DEFAULT_PLUGINS_JSON);
             log.debug("Read plugins of '{}' repository from '{}'", id, pluginsUrl);
             pluginsJsonReader = new InputStreamReader(pluginsUrl.openStream());
         } catch (Exception e) {

--- a/src/main/java/ro/fortsoft/pf4j/update/UpdateRepository.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/UpdateRepository.java
@@ -21,10 +21,11 @@ import com.google.gson.GsonBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.io.Serializable;
+import java.net.URI;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -76,20 +77,19 @@ public class UpdateRepository {
     }
 
     private void initPlugins() {
-        FileReader reader;
+        Reader pluginsJsonReader;
         try {
-            String pluginsUrl = url + pluginsJson;
+            URL pluginsUrl = (new URI(url)).resolve(pluginsJson).toURL();
             log.debug("Read plugins of '{}' repository from '{}'", id, pluginsUrl);
-            File pluginsFile = new FileDownloader().downloadFile(pluginsUrl);
-            reader = new FileReader(pluginsFile);
-        } catch (IOException e) {
+            pluginsJsonReader = new InputStreamReader(pluginsUrl.openStream());
+        } catch (Exception e) {
             log.error(e.getMessage(), e);
             plugins = Collections.emptyList();
             return;
         }
 
         Gson gson = new GsonBuilder().create();
-        PluginInfo[] items = gson.fromJson(reader, PluginInfo[].class);
+        PluginInfo[] items = gson.fromJson(pluginsJsonReader, PluginInfo[].class);
         plugins = Arrays.asList(items);
         log.debug("Found {} plugins in repository '{}'", plugins.size(), id);
 


### PR DESCRIPTION
Today, each UpdateRepository downloads its `plugins.json` to the plugins folder, but it is only ever used in that same method to initialize the `PluginInfo`. This PR uses an InputStreamReader instead.