### PR TITLE
Bugfix refresh(), add Repositories setter, various fixes

### DIFF
--- a/src/main/java/ro/fortsoft/pf4j/update/UpdateRepository.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/UpdateRepository.java
@@ -100,6 +100,13 @@ public class UpdateRepository {
         }
     }
 
+    /**
+     * Causes plugins.json to be read again to look for new updates from repos
+     */
+    public void refresh() {
+        plugins = null;
+    }
+
     public static class PluginInfo implements Serializable {
 
         public String id;
@@ -136,7 +143,8 @@ public class UpdateRepository {
         }
 
         public boolean hasUpdate(Version systemVersion, Version installedVersion) {
-            return Version.valueOf(getLastRelease(systemVersion).version).greaterThan(installedVersion);
+            PluginRelease last = getLastRelease(systemVersion);
+            return last != null && Version.valueOf(last.version).greaterThan(installedVersion);
         }
 
     }


### PR DESCRIPTION
Allow empty list of repos initially, add `setRepositories()`
Fix `refresh()` to work also when Repositories given in constructor or setter
Optimize `getUpdates()` by iterating installed plugins rather than plugins from repos
Removed code duplication in `hasUpdates()`
Safeguard against nullpointer in `UpdateRepository.hasUpdate()`