### PR TITLE
Pluggable UpdateRepositories

### DIFF
--- a/src/main/java/ro/fortsoft/pf4j/update/DefaultUpdateRepository.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/DefaultUpdateRepository.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2014 Decebal Suiu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.fortsoft.pf4j.update;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ro.fortsoft.pf4j.update.PluginInfo.PluginRelease;
+
+import java.io.*;
+import java.net.*;
+import java.util.*;
+
+/**
+ * @author Decebal Suiu
+ */
+public class DefaultUpdateRepository implements UpdateRepository {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultUpdateRepository.class);
+
+    private static final String DEFAULT_PLUGINS_JSON = "plugins.json";
+
+    private String id;
+    private String url;
+    private Map<String, PluginInfo> plugins;
+
+    public DefaultUpdateRepository(String id, String url) {
+        this.id = id;
+        this.url = url;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getLocation() {
+        return url;
+    }
+
+    public Map<String, PluginInfo> getPlugins() {
+        if (plugins == null) {
+            initPlugins();
+        }
+
+        return plugins;
+    }
+
+    public PluginInfo getPlugin(String id) {
+        return getPlugins().get(id);
+    }
+
+    private void initPlugins() {
+        Reader pluginsJsonReader;
+        try {
+            URL pluginsUrl = new URL(new URL(url), DEFAULT_PLUGINS_JSON);
+            log.debug("Read plugins of '{}' repository from '{}'", id, pluginsUrl);
+            pluginsJsonReader = new InputStreamReader(pluginsUrl.openStream());
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            plugins = Collections.emptyMap();
+            return;
+        }
+
+        Gson gson = new GsonBuilder().create();
+        PluginInfo[] items = gson.fromJson(pluginsJsonReader, PluginInfo[].class);
+        plugins = new HashMap<>(items.length);
+        for (PluginInfo p : items) {
+            for (PluginRelease r : p.releases) {
+                try {
+                    r.url = new URL(new URL(url), r.url).toString();
+                } catch (MalformedURLException e) {
+                    log.warn("Skipping release {} of plugin {} due to failure to build valid absolute URL. Url was {}{}", r.version, p.id, url, r.url);
+                }
+            }
+            plugins.put(p.id, p);
+        }
+        log.debug("Found {} plugins in repository '{}'", plugins.size(), id);
+    }
+
+    /**
+     * Causes plugins.json to be read again to look for new updates from repos
+     */
+    public void refresh() {
+        plugins = null;
+    }
+
+    @Override
+    public FileDownloader getFileDownloader() {
+        return new SimpleFileDownloader();
+    }
+
+}

--- a/src/main/java/ro/fortsoft/pf4j/update/FileDownloader.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/FileDownloader.java
@@ -1,113 +1,21 @@
-/*
- * Copyright 2014 Decebal Suiu
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package ro.fortsoft.pf4j.update;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import ro.fortsoft.pf4j.PluginException;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.ConnectException;
-import java.net.HttpURLConnection;
 import java.net.URL;
-import java.net.URLConnection;
+import java.nio.file.Path;
 
 /**
- * Downloads a file from a URL.
- *
- * @author Decebal Suiu
+ * Interface to download a file
  */
-class FileDownloader {
-
-    private static final Logger log = LoggerFactory.getLogger(FileDownloader.class);
-
-    private static final String pluginsDir = System.getProperty("pf4j.pluginsDir", "plugins");
-
-    public File downloadFile(String fileUrl) throws IOException {
-        File plugins = new File(pluginsDir);
-        plugins.mkdirs();
-
-        // create a temporary file
-        File tmpFile = new File(pluginsDir, DigestUtils.getSHA1(fileUrl) + ".tmp");
-        if (tmpFile.exists()) {
-            tmpFile.delete();
-        }
-
-        log.debug("Download '{}' to '{}'", fileUrl, tmpFile);
-
-        // create the url
-        URL url = new URL(fileUrl);
-
-        // set up the URL connection
-        URLConnection connection = url.openConnection();
-
-        // connect to the remote site (may takes some time)
-        connection.connect();
-
-        // check for http authorization
-        HttpURLConnection httpConnection = (HttpURLConnection) connection;
-        if (httpConnection.getResponseCode() == HttpURLConnection.HTTP_UNAUTHORIZED) {
-            throw new ConnectException("HTTP Authorization failure");
-        }
-
-        // try to get the server-specified last-modified date of this artifact
-        long lastModified = httpConnection.getHeaderFieldDate("Last-Modified", System.currentTimeMillis());
-
-        // try to get the input stream (three times)
-        InputStream is = null;
-        for (int i = 0; i < 3; i++) {
-            try {
-                is = connection.getInputStream();
-                break;
-            } catch (IOException e) {
-                log.error(e.getMessage(), e);
-            }
-        }
-        if (is == null) {
-            throw new ConnectException("Can't get '" + url + " to '" + tmpFile + "'");
-        }
-
-        // reade from remote resource and write to the local file
-        FileOutputStream fos = new FileOutputStream(tmpFile);
-        byte[] buffer = new byte[1024];
-        int length;
-        while ((length = is.read(buffer)) >= 0) {
-            fos.write(buffer, 0, length);
-        }
-        fos.close();
-        is.close();
-
-        // rename tmp file to resource file
-        String path = url.getPath();
-        String fileName = path.substring(path.lastIndexOf('/') + 1);
-        File file = new File(plugins, fileName);
-        if (file.exists()) {
-            log.debug("Delete old '{}' resource file", file);
-            file.delete();
-        }
-        log.debug("Rename '{}' to {}", tmpFile, file);
-        tmpFile.renameTo(file);
-
-
-        log.debug("Set last modified of '{}' to '{}'", file, lastModified);
-        file.setLastModified(lastModified);
-
-        return file;
-    }
-
+public interface FileDownloader {
+    /**
+     * Downloads a file to destination. The implementation should download to a temporary folder
+     * @param fileUrl the file to download
+     * @return Path of downloaded file, typically in a temporary folder
+     * @throws IOException if there was an IO problem during download
+     * @throws PluginException if file could be downloaded but there were other problems
+     */
+    public Path downloadFile(URL fileUrl) throws PluginException, IOException;
 }

--- a/src/main/java/ro/fortsoft/pf4j/update/FileDownloader.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/FileDownloader.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 Decebal Suiu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package ro.fortsoft.pf4j.update;
 
 import ro.fortsoft.pf4j.PluginException;

--- a/src/main/java/ro/fortsoft/pf4j/update/PluginInfo.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/PluginInfo.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 Decebal Suiu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.fortsoft.pf4j.update;
+
+import com.github.zafarkhaja.semver.Version;
+import com.github.zafarkhaja.semver.expr.Expression;
+import com.github.zafarkhaja.semver.expr.ExpressionParser;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * PluginInfo describing a plugin from a repo
+ */
+public class PluginInfo implements Serializable, Comparable<PluginInfo> {
+
+    public String id;
+    public String name;
+    public String description;
+    public String provider;
+    public String projectUrl;
+    public List<PluginRelease> releases;
+
+    // Cache lastRelease per system version
+    private Map<Version, PluginRelease> lastRelease = new HashMap<>();
+
+    /**
+     * Returns the last release version of this plugin for given system version, regardless of release date
+     * @param systemVersion version of host system where plugin will be installed
+     * @return PluginRelease which has the highest version number
+     */
+    public PluginRelease getLastRelease(Version systemVersion) {
+        if (!lastRelease.containsKey(systemVersion)) {
+            for (PluginRelease release : releases) {
+                Expression requires = release.getRequiresExpression();
+
+                if (systemVersion.equals(Version.forIntegers(0, 0, 0)) || systemVersion.satisfies(requires)) {
+                    if (lastRelease.get(systemVersion) == null) {
+                        lastRelease.put(systemVersion, release);
+                    } else if (release.compareTo(lastRelease.get(systemVersion)) > 0) {
+                        lastRelease.put(systemVersion, release);
+                    }
+                }
+            }
+        }
+
+        return lastRelease.get(systemVersion);
+    }
+
+    /**
+     * Finds whether the repo has a newer version of the plugin
+     * @param systemVersion version of host system where plugin will be installed
+     * @param installedVersion version that is already installed
+     * @return true if there is a newer version available which is compatible with system
+     */
+    public boolean hasUpdate(Version systemVersion, Version installedVersion) {
+        PluginRelease last = getLastRelease(systemVersion);
+        return last != null && Version.valueOf(last.version).greaterThan(installedVersion);
+    }
+
+    @Override
+    public int compareTo(PluginInfo o) {
+        return id.compareTo(o.id);
+    }
+
+    public static class PluginRelease implements Serializable, Comparable<PluginRelease> {
+        public String version;
+        public Date date;
+        public String requires;
+        public String url;
+
+        @Override
+        public int compareTo(PluginRelease o) {
+            return Version.valueOf(version).compareTo(Version.valueOf(o.version));
+        }
+
+        /**
+         * Get the required version as a SemVer Expression
+         * @return Expression object that can be compared to a Version. If requires is empty, a wildcard version is returned
+         */
+        public Expression getRequiresExpression() {
+            return ExpressionParser.newInstance().parse(requires == null ? "*" : requires);
+        }
+    }
+}

--- a/src/main/java/ro/fortsoft/pf4j/update/SimpleFileDownloader.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/SimpleFileDownloader.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017 Decebal Suiu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.fortsoft.pf4j.update;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ro.fortsoft.pf4j.PluginException;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ConnectException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+
+/**
+ * Downloads a file from a URL.
+ *
+ * @author Decebal Suiu
+ */
+public class SimpleFileDownloader implements FileDownloader {
+
+    private static final Logger log = LoggerFactory.getLogger(SimpleFileDownloader.class);
+
+    public Path downloadFile(URL fileUrl) throws PluginException, IOException {
+        Path destination = Files.createTempDirectory("pf4j-update-downloader");
+        destination.toFile().deleteOnExit();
+
+        // create a temporary file
+        Path tmpFile = destination.resolve(DigestUtils.getSHA1(fileUrl.toString()) + ".tmp");
+        Files.deleteIfExists(tmpFile);
+
+        log.debug("Download '{}' to '{}'", fileUrl, tmpFile);
+
+        // set up the URL connection
+        URLConnection connection = fileUrl.openConnection();
+
+        // connect to the remote site (may takes some time)
+        connection.connect();
+
+        // check for http authorization
+        HttpURLConnection httpConnection = (HttpURLConnection) connection;
+        if (httpConnection.getResponseCode() == HttpURLConnection.HTTP_UNAUTHORIZED) {
+            throw new ConnectException("HTTP Authorization failure");
+        }
+
+        // try to get the server-specified last-modified date of this artifact
+        long lastModified = httpConnection.getHeaderFieldDate("Last-Modified", System.currentTimeMillis());
+
+        // try to get the input stream (three times)
+        InputStream is = null;
+        for (int i = 0; i < 3; i++) {
+            try {
+                is = connection.getInputStream();
+                break;
+            } catch (IOException e) {
+                log.error(e.getMessage(), e);
+            }
+        }
+        if (is == null) {
+            throw new ConnectException("Can't get '" + fileUrl + " to '" + tmpFile + "'");
+        }
+
+        // reade from remote resource and write to the local file
+        FileOutputStream fos = new FileOutputStream(tmpFile.toFile());
+        byte[] buffer = new byte[1024];
+        int length;
+        while ((length = is.read(buffer)) >= 0) {
+            fos.write(buffer, 0, length);
+        }
+        fos.close();
+        is.close();
+
+        // rename tmp file to resource file
+        String path = fileUrl.getPath();
+        String fileName = path.substring(path.lastIndexOf('/') + 1);
+        Path file = destination.resolve(fileName);
+        Files.deleteIfExists(file);
+        log.debug("Rename '{}' to {}", tmpFile, file);
+        Files.move(tmpFile, file);
+
+        log.debug("Set last modified of '{}' to '{}'", file, lastModified);
+        Files.setLastModifiedTime(file, FileTime.fromMillis(lastModified));
+
+        return file;
+    }
+
+}

--- a/src/main/java/ro/fortsoft/pf4j/update/UpdateManager.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/UpdateManager.java
@@ -112,7 +112,7 @@ public class UpdateManager {
      * @return List of plugin info
      */
     public List<PluginInfo> getPlugins() {
-        ArrayList<PluginInfo> list = new ArrayList<>(getPluginsMap().values());
+        List<PluginInfo> list = new ArrayList<>(getPluginsMap().values());
         Collections.sort(list);
         return list;
     }

--- a/src/main/java/ro/fortsoft/pf4j/update/UpdateManager.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/UpdateManager.java
@@ -20,15 +20,12 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import ro.fortsoft.pf4j.PluginManager;
-import ro.fortsoft.pf4j.PluginState;
-import ro.fortsoft.pf4j.PluginWrapper;
-import ro.fortsoft.pf4j.update.UpdateRepository.PluginInfo;
+import ro.fortsoft.pf4j.*;
+import ro.fortsoft.pf4j.update.PluginInfo.PluginRelease;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
+import java.io.*;
+import java.net.*;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
@@ -63,8 +60,7 @@ public class UpdateManager {
 
     public List<PluginInfo> getAvailablePlugins() {
         List<PluginInfo> availablePlugins = new ArrayList<>();
-        List<PluginInfo> plugins = getPlugins();
-        for (PluginInfo plugin : plugins) {
+        for (PluginInfo plugin : getPlugins()) {
             if (pluginManager.getPlugin(plugin.id) == null) {
                 availablePlugins.add(plugin);
             }
@@ -74,8 +70,7 @@ public class UpdateManager {
     }
 
     public boolean hasAvailablePlugins() {
-        List<PluginInfo> plugins = getPlugins();
-        for (PluginInfo plugin : plugins) {
+        for (PluginInfo plugin : getPlugins()) {
             if (pluginManager.getPlugin(plugin.id) == null) {
                 return true;
             }
@@ -117,13 +112,9 @@ public class UpdateManager {
      * @return List of plugin info
      */
     public List<PluginInfo> getPlugins() {
-        List<PluginInfo> plugins = new ArrayList<>();
-        List<UpdateRepository> repositories = getRepositories();
-        for (UpdateRepository repository : repositories) {
-            plugins.addAll(repository.getPlugins());
-        }
-
-        return plugins;
+        ArrayList<PluginInfo> list = new ArrayList<>(getPluginsMap().values());
+        Collections.sort(list);
+        return list;
     }
 
     /**
@@ -132,9 +123,10 @@ public class UpdateManager {
      */
     public Map<String, PluginInfo> getPluginsMap() {
         Map<String, PluginInfo> pluginsMap = new HashMap<>();
-        for (PluginInfo plugin : getPlugins()) {
-            pluginsMap.put(plugin.id, plugin);
+        for (UpdateRepository repository : getRepositories()) {
+            pluginsMap.putAll(repository.getPlugins());
         }
+
         return pluginsMap;
     }
 
@@ -146,12 +138,61 @@ public class UpdateManager {
         return repositories;
     }
 
+
+    /**
+     * Replace all repositories
+     * @param repositories list of new repositories
+     */
     public void setRepositories(List<UpdateRepository> repositories) {
         this.repositories = repositories;
         refresh();
     }
 
+    /**
+     * Add one DefaultUpdateRepository
+     * @param id of repo
+     * @param url of repo
+     */
+    public void addRepository(String id, String url) {
+        for (UpdateRepository ur : repositories) {
+            if (ur.getId().equals(id)) {
+                throw new RuntimeException("Repository with id " + id + " already exists");
+            }
+        }
+        repositories.add(new DefaultUpdateRepository(id, url));
+    }
 
+    /**
+     * Add a repo that was created by client
+     * @param newRepo
+     */
+    public void addRepository(UpdateRepository newRepo) {
+        for (UpdateRepository ur : repositories) {
+            if (ur.getId().equals(newRepo.getId())) {
+                throw new RuntimeException("Repository with id " + newRepo.getId() + " already exists");
+            }
+        }
+        newRepo.refresh();
+        repositories.add(newRepo);
+    }
+
+    /**
+     * Remove a repository by id
+     * @param id of repository to remove
+     */
+    public void removeRepository(String id) {
+      for (UpdateRepository repo : getRepositories()) {
+        if (id == repo.getId()) {
+          repositories.remove(repo);
+          break;
+        }
+      }
+      log.warn("Repository with id " + id + " not found, doing nothing");
+    }
+
+    /**
+     * Refreshes all repositories, so they are forced to refresh list of plugins
+     */
     public synchronized void refresh() {
         if (repositoriesJson != null) {
             initRepositoriesFromJson();
@@ -161,38 +202,136 @@ public class UpdateManager {
         }
     }
 
-    public synchronized boolean installPlugin(String url) {
-        File pluginArchiveFile;
+    /**
+     * Installs a plugin given only its URL
+     * @param url the url of the plugin to install
+     * @return true if plugin was installed
+     * @deprecated - use the installPlugin(id, version) instead
+     */
+    public boolean installPlugin(String url) {
+        FileDownloader downloader = new SimpleFileDownloader();
         try {
-            pluginArchiveFile = new FileDownloader().downloadFile(url);
-        } catch (IOException e) {
-            log.error(e.getMessage(), e);
-            return false;
+            Path downloaded = downloader.downloadFile(new URL(url));
+
+            // TODO: Add getPluginsRoot to interface PluginManager
+            Path pluginsRoot = ((AbstractPluginManager)pluginManager).getPluginsRoot();
+            Path file = pluginsRoot.resolve(downloaded.getFileName());
+            Files.move(downloaded, file);
+
+            String newPluginId = pluginManager.loadPlugin(file);
+            PluginState state = pluginManager.startPlugin(newPluginId);
+
+            return PluginState.STARTED.equals(state);
+        } catch (Exception e) {
+            log.error("Plugin at " + url + " not installed.", e);
         }
+        return false;
+    }
 
-        String pluginId = pluginManager.loadPlugin(pluginArchiveFile.toPath());
-        PluginState state = pluginManager.startPlugin(pluginId);
+    /**
+     * Installs a plugin by URL
+     * @param id the id of plugin to install
+     * @param version the version of plugin to install, on SemVer format
+     * @return true if installation successful and plugin started
+     */
+    public synchronized boolean installPlugin(String id, String version) {
+        Path downloaded = null;
+        try {
+            // Download to temporary location
+            downloaded = downloadPlugin(id, version);
+            // TODO: Add getPluginsRoot to interface PluginManager
+            Path pluginsRoot = ((AbstractPluginManager)pluginManager).getPluginsRoot();
+            Path file = pluginsRoot.resolve(downloaded.getFileName());
+            Files.move(downloaded, file);
 
-        return PluginState.STARTED.equals(state);
+            String pluginId = pluginManager.loadPlugin(file);
+            PluginState state = pluginManager.startPlugin(pluginId);
+
+            return PluginState.STARTED.equals(state);
+        } catch (Exception e) {
+            log.error("Plugin " + id + "@" + version + " not installed.", e);
+        }
+        return false;
+    }
+
+    /**
+     * Downloads a plugin with given coordinates and returns a path to the file
+     * @param id of plugin
+     * @param version of plugin
+     * @return Path to file which will reside in a temporary folder in the system default temp area
+     * @throws PluginException if download failed
+     */
+    protected Path downloadPlugin(String id, String version) throws PluginException {
+        try {
+            URL url = findUrlForPlugin(id, version);
+            return getFileDownloader(id).downloadFile(url);
+        } catch (IOException e) {
+            throw new PluginException("Error during download of plugin " + id, e);
+        }
+    }
+
+    /**
+     * Finds the FileDownloader to use for this repository
+     * @param pluginId the plugin we wish to download
+     * @return FileDownloader instance
+     */
+    protected FileDownloader getFileDownloader(String pluginId) {
+        for (UpdateRepository ur : repositories) {
+            if (ur.getPlugin(pluginId) != null && ur.getFileDownloader() != null) {
+                return ur.getFileDownloader();
+            }
+        }
+        return new SimpleFileDownloader();
+    }
+
+    /**
+     * Resolves url from id and version
+     * @param id of plugin
+     * @param version of plugin
+     * @return URL for downloading
+     * @throws PluginException if id or version does not exist
+     */
+    protected URL findUrlForPlugin(String id, String version) throws PluginException {
+        PluginInfo plugin = getPluginsMap().get(id);
+        if (plugin == null) {
+            log.info("Plugin with id {} does not exist in any repository", id);
+            throw new PluginException("Plugin with id " + id + " not found in any repository");
+        }
+        for (PluginRelease release : plugin.releases) {
+            if (Version.valueOf(version).equals(Version.valueOf(release.version)) && release.url != null) {
+                try {
+                    return new URL(release.url);
+                } catch (MalformedURLException e) {
+                    throw new PluginException("Release URL " + release.url + " is not a valid URL", e);
+                }
+            }
+        }
+        throw new PluginException("Plugin " + id + " with version @" + version + " does not exist in the repository");
     }
 
     public boolean updatePlugin(String id, String url) {
-        File pluginArchiveFile;
         try {
-            pluginArchiveFile = new FileDownloader().downloadFile(url);
-        } catch (IOException e) {
-            log.error(e.getMessage(), e);
-            return false;
+            // Download to temp folder
+            Path downloaded = getFileDownloader(id).downloadFile(new URL(url));
+
+            if (!pluginManager.deletePlugin(id)) {
+                return false;
+            }
+
+            // TODO: Add getPluginsRoot to interface PluginManager
+            Path pluginsRoot = ((AbstractPluginManager)pluginManager).getPluginsRoot();
+            Path file = pluginsRoot.resolve(downloaded.getFileName());
+            Files.move(downloaded, file);
+
+            String newPluginId = pluginManager.loadPlugin(file);
+            PluginState state = pluginManager.startPlugin(newPluginId);
+
+            return PluginState.STARTED.equals(state);
+
+        } catch (Exception e) {
+            log.error("Error while updating plugin " + id, e);
         }
-
-        if (!pluginManager.deletePlugin(id)) {
-            return false;
-        }
-
-        String newPluginId = pluginManager.loadPlugin(pluginArchiveFile.toPath());
-        PluginState state = pluginManager.startPlugin(newPluginId);
-
-        return PluginState.STARTED.equals(state);
+        return false;
     }
 
     public boolean uninstallPlugin(String id) {
@@ -211,7 +350,7 @@ public class UpdateManager {
         }
 
         Gson gson = new GsonBuilder().create();
-        UpdateRepository[] items = gson.fromJson(reader, UpdateRepository[].class);
+        UpdateRepository[] items = gson.fromJson(reader, DefaultUpdateRepository[].class);
 
         repositories = Arrays.asList(items);
     }

--- a/src/main/java/ro/fortsoft/pf4j/update/UpdateRepository.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/UpdateRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Decebal Suiu
+ * Copyright 2017 Decebal Suiu
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,164 +15,45 @@
  */
 package ro.fortsoft.pf4j.update;
 
-import com.github.zafarkhaja.semver.Version;
-import com.github.zafarkhaja.semver.expr.Expression;
-import com.github.zafarkhaja.semver.expr.ExpressionParser;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.Serializable;
-import java.net.URL;
-import java.util.*;
+import java.util.Map;
 
 /**
- * @author Decebal Suiu
+ * Contract for update repositories
  */
-public class UpdateRepository {
-
-    private static final Logger log = LoggerFactory.getLogger(UpdateRepository.class);
-
-    private static final String DEFAULT_PLUGINS_JSON = "plugins.json";
-
-    private String id;
-    private String url;
-    private List<PluginInfo> plugins;
-
-    public UpdateRepository(String id, String url) {
-        this.id = id;
-        this.url = url;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public String getUrl() {
-        return url;
-    }
-
-    public List<PluginInfo> getPlugins() {
-        if (plugins == null) {
-            initPlugins();
-        }
-
-        return plugins;
-    }
-
-    public PluginInfo getPlugin(String id) {
-        List<PluginInfo> plugins = getPlugins();
-        for (PluginInfo plugin : plugins) {
-            if (plugin.id.equals(id)) {
-                return plugin;
-            }
-        }
-
-        return null;
-    }
-
-    private void initPlugins() {
-        Reader pluginsJsonReader;
-        try {
-            URL pluginsUrl = new URL(new URL(url), DEFAULT_PLUGINS_JSON);
-            log.debug("Read plugins of '{}' repository from '{}'", id, pluginsUrl);
-            pluginsJsonReader = new InputStreamReader(pluginsUrl.openStream());
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
-            plugins = Collections.emptyList();
-            return;
-        }
-
-        Gson gson = new GsonBuilder().create();
-        PluginInfo[] items = gson.fromJson(pluginsJsonReader, PluginInfo[].class);
-        plugins = Arrays.asList(items);
-        log.debug("Found {} plugins in repository '{}'", plugins.size(), id);
-
-        // for each release makes the url absolute
-        for (PluginInfo plugin : plugins) {
-            for (PluginRelease release : plugin.releases) {
-                release.url = url + release.url; // add repository's url as prefix to release' url
-            }
-        }
-    }
+public interface UpdateRepository {
+    /**
+     * @return the ID of this repo. This must be unique
+     */
+    public String getId();
 
     /**
-     * Causes plugins.json to be read again to look for new updates from repos
+     * @return the location of this repo as a String. Typically a URL
      */
-    public void refresh() {
-        plugins = null;
-    }
+    public String getLocation();
 
-    public static class PluginInfo implements Serializable {
+    /**
+     * Get all plugin descriptors for this repo
+     * @return Map of PluginId and PluginInfo
+     */
+    public Map<String, PluginInfo> getPlugins();
 
-        public String id;
-        public String name;
-        public String description;
-        public String provider;
-        public String projectUrl;
-        public List<PluginRelease> releases;
+    /**
+     * Get a particular plugin from this repo
+     * @param id the id of the plugin
+     * @return the PluginInfo
+     */
+    public PluginInfo getPlugin(String id);
 
-        // Cache lastRelease per system version
-        private Map<Version, PluginRelease> lastRelease = new HashMap<>();
+    /**
+     * Flushes cached info to force re-fetching repository state on next get
+     */
+    public void refresh();
 
-        /**
-         * Returns the last release version of this plugin for given system version, regardless of release date
-         * @param systemVersion version of host system where plugin will be installed
-         * @return PluginRelease which has the highest version number
-         */
-        public PluginRelease getLastRelease(Version systemVersion) {
-            if (!lastRelease.containsKey(systemVersion)) {
-                for (PluginRelease release : releases) {
-                    Expression requires = release.getRequiresExpression();
-
-                    if (systemVersion.equals(Version.forIntegers(0, 0, 0)) || systemVersion.satisfies(requires)) {
-                        if (lastRelease.get(systemVersion) == null) {
-                            lastRelease.put(systemVersion, release);
-                        } else if (release.compareTo(lastRelease.get(systemVersion)) > 0) {
-                            lastRelease.put(systemVersion, release);
-                        }
-                    }
-                }
-            }
-
-            return lastRelease.get(systemVersion);
-        }
-
-        /**
-         * Finds whether the repo has a newer version of the plugin
-         * @param systemVersion version of host system where plugin will be installed
-         * @param installedVersion version that is already installed
-         * @return true if there is a newer version available which is compatible with system
-         */
-        public boolean hasUpdate(Version systemVersion, Version installedVersion) {
-            PluginRelease last = getLastRelease(systemVersion);
-            return last != null && Version.valueOf(last.version).greaterThan(installedVersion);
-        }
-
-    }
-
-    public static class PluginRelease implements Serializable, Comparable<PluginRelease> {
-
-        public String version;
-        public Date date;
-        public String requires;
-        public String url;
-
-        @Override
-        public int compareTo(PluginRelease o) {
-            return Version.valueOf(version).compareTo(Version.valueOf(o.version));
-        }
-
-        /**
-         * Get the required version as a SemVer Expression
-         * @return Expression object that can be compared to a Version. If requires is empty, a wildcard version is returned
-         */
-        public Expression getRequiresExpression() {
-            return ExpressionParser.newInstance().parse(requires == null ? "*" : requires);
-        }
-    }
-
+    /**
+     * Each repository has the option of overriding the download process.
+     * They can e.g. do checksumming, signature verifications etc.
+     * To use the default downloader, return null
+     * @return the FileDownloader to use for this repository or null if you do not wish to override
+     */
+    FileDownloader getFileDownloader();
 }

--- a/src/test/java/ro/fortsoft/pf4j/update/PluginInfoTest.java
+++ b/src/test/java/ro/fortsoft/pf4j/update/PluginInfoTest.java
@@ -18,8 +18,7 @@ package ro.fortsoft.pf4j.update;
 import com.github.zafarkhaja.semver.Version;
 import org.junit.Before;
 import org.junit.Test;
-import ro.fortsoft.pf4j.update.UpdateRepository.PluginInfo;
-import ro.fortsoft.pf4j.update.UpdateRepository.PluginRelease;
+import ro.fortsoft.pf4j.update.PluginInfo.PluginRelease;
 
 import java.util.Arrays;
 
@@ -30,6 +29,7 @@ import static org.junit.Assert.*;
  */
 public class PluginInfoTest {
     private PluginInfo pi1;
+    private PluginInfo pi2;
 
     @Before
     public void setup() {
@@ -45,6 +45,16 @@ public class PluginInfoTest {
         pi1r3.version = "1.2.0";
         pi1r3.requires = ">2.5 & < 4";
         pi1.releases = Arrays.asList(pi1r1, pi1r2, pi1r3);
+        pi2 = new PluginInfo();
+        PluginRelease pi2r1 = new PluginRelease();
+        pi2r1.version = "1.0.0";
+        pi2.id = "aaa";
+        pi2.releases = Arrays.asList(pi2r1);
+    }
+
+    @Test
+    public void comparePluginInfo() {
+        assertTrue(pi1.compareTo(pi2) > 0);
     }
 
     @Test

--- a/src/test/java/ro/fortsoft/pf4j/update/PluginsTest.java
+++ b/src/test/java/ro/fortsoft/pf4j/update/PluginsTest.java
@@ -42,27 +42,27 @@ public class PluginsTest {
         }
 
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        List<UpdateRepository.PluginInfo> plugins = new ArrayList<>();
+        List<PluginInfo> plugins = new ArrayList<>();
 
         // plugin 1
-        UpdateRepository.PluginInfo p1 = new UpdateRepository.PluginInfo();
+        PluginInfo p1 = new PluginInfo();
         p1.id = "welcome-plugin";
         p1.description = "Welcome plugin";
         plugins.add(p1);
         // releases for plugin 1
-        UpdateRepository.PluginRelease p1r1 = new UpdateRepository.PluginRelease();
+        PluginInfo.PluginRelease p1r1 = new PluginInfo.PluginRelease();
         p1r1.version = "0.9.0";
         p1r1.date = new Date();
         p1r1.url = "pf4j-demo-plugin1/0.9.0/pf4j-demo-plugin1-0.9.0-SNAPSHOT.zip";
         p1.releases = Arrays.asList(p1r1);
 
         // plugin 2
-        UpdateRepository.PluginInfo p2 = new UpdateRepository.PluginInfo();
+        PluginInfo p2 = new PluginInfo();
         p2.id = "hello-plugin";
         p2.description = "Hello plugin";
         plugins.add(p2);
         // releases for plugin 2
-        UpdateRepository.PluginRelease p2r1 = new UpdateRepository.PluginRelease();
+        PluginInfo.PluginRelease p2r1 = new PluginInfo.PluginRelease();
         p2r1.version = "0.9.0";
         p2r1.date = new Date();
         p2r1.url = "pf4j-demo-plugin2/0.9.0/pf4j-demo-plugin2-0.9.0-SNAPSHOT.zip";

--- a/src/test/java/ro/fortsoft/pf4j/update/RepositoriesTest.java
+++ b/src/test/java/ro/fortsoft/pf4j/update/RepositoriesTest.java
@@ -42,7 +42,7 @@ public class RepositoriesTest {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         List<UpdateRepository> repositories = new ArrayList<UpdateRepository>();
 //        repositories.add(new UpdateRepository("local", "file:/home/decebal_suiu/work/pf4j-update/plugins/"));
-        repositories.add(new UpdateRepository("localhost", "http://localhost:8081/"));
+        repositories.add(new DefaultUpdateRepository("localhost", "http://localhost:8081/"));
 //        repositories.add(new UpdateRepository("localhost2", "http://localhost:8088/"));
 //        repositories.add(new UpdateRepository("localhost3", "http://localhost:8888/"));
 

--- a/src/test/java/ro/fortsoft/pf4j/update/UpdateTest.java
+++ b/src/test/java/ro/fortsoft/pf4j/update/UpdateTest.java
@@ -59,11 +59,11 @@ public class UpdateTest {
 
         // check for updates
         if (updateManager.hasUpdates()) {
-            List<UpdateRepository.PluginInfo> updates = updateManager.getUpdates();
+            List<PluginInfo> updates = updateManager.getUpdates();
             log.debug("Found {} updates", updates.size());
-            for (UpdateRepository.PluginInfo plugin : updates) {
+            for (PluginInfo plugin : updates) {
                 log.debug("Found update for plugin '{}'", plugin.id);
-                UpdateRepository.PluginRelease lastRelease = plugin.getLastRelease(systemVersion);
+                PluginInfo.PluginRelease lastRelease = plugin.getLastRelease(systemVersion);
                 String lastVersion = lastRelease.version;
                 String installedVersion = pluginManager.getPlugin(plugin.id).getDescriptor().getVersion().toString();
                 log.debug("Update plugin '{}' from version {} to version {}", plugin.id, installedVersion, lastVersion);
@@ -81,11 +81,11 @@ public class UpdateTest {
 
         // check for available (new) plugins
         if (updateManager.hasAvailablePlugins()) {
-            List<UpdateRepository.PluginInfo> availablePlugins = updateManager.getAvailablePlugins();
+            List<PluginInfo> availablePlugins = updateManager.getAvailablePlugins();
             log.debug("Found {} available plugins", availablePlugins.size());
-            for (UpdateRepository.PluginInfo plugin : availablePlugins) {
+            for (PluginInfo plugin : availablePlugins) {
                 log.debug("Found available plugin '{}'", plugin.id);
-                UpdateRepository.PluginRelease lastRelease = plugin.getLastRelease(systemVersion);
+                PluginInfo.PluginRelease lastRelease = plugin.getLastRelease(systemVersion);
                 String lastVersion = lastRelease.version;
                 log.debug("Install plugin '{}' with version {}", plugin.id, lastVersion);
                 boolean installed = updateManager.installPlugin(lastRelease.url);


### PR DESCRIPTION
First shot at pluggable update repos
There are still some TODOs, since we'd want a `PluginManager.getPluginsRoot` to get the true plugins root instead of defaulting to the property or "plugins". Also there are several breaking changes resulting from `PluginInfo` being moved out to its own class, and I also deprecated `installPlugin(String url)` in favor of `installPlugin(String id, String version)` to be able to lookup the correct repository based on ID and get the FileDownloader from there.

The new `FileDownloader` interface lets repositories implement their custom download handling, or fallback to `SimpleFileDownloader` if they want.

I realize the PR is huge and probably could be broken up, but on top of this I have now successfully implemented [ApacheMirrorsUpdateRepository](https://github.com/cominvent/lucene-solr/blob/pf4j/solr/core/src/java/org/apache/solr/util/modules/ApacheMirrorsUpdateRepository.java) with a custom `ApacheChecksumVerifyingDownloader` that fails the download if the checksum does not match the one from the official `.md5` file.

So guess I throw this out here for initial comments and iterate from there :)

Fixes #10 