### PR TITLE
Add validateDownload hook to SimpleFileDownloader

### DIFF
--- a/src/main/java/ro/fortsoft/pf4j/update/SimpleFileDownloader.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/SimpleFileDownloader.java
@@ -75,6 +75,7 @@ public class SimpleFileDownloader implements FileDownloader {
             String fileName = path.substring(path.lastIndexOf('/') + 1);
             Path toFile = destination.resolve(fileName);
             Files.copy(fromFile, toFile, StandardCopyOption.COPY_ATTRIBUTES, StandardCopyOption.REPLACE_EXISTING);
+            validateDownload(fileUrl, toFile);
             return toFile;
         } catch (URISyntaxException e) {
             throw new PluginException("Something wrong with given URL", e);
@@ -137,7 +138,23 @@ public class SimpleFileDownloader implements FileDownloader {
         log.debug("Set last modified of '{}' to '{}'", file, lastModified);
         Files.setLastModifiedTime(file, FileTime.fromMillis(lastModified));
 
+        validateDownload(fileUrl, file);
         return file;
     }
 
+    /**
+     * Succeeds if downloaded file exists and has size > 0
+     * <p>Override this method to provide your own validation rules such as content length matching or checksum checking etc</p>
+     * @param originalUrl the source from which the file was downloaded
+     * @param downloadedFile the path to the downloaded file
+     * @throws PluginException if the validation failed
+     */
+    protected void validateDownload(URL originalUrl, Path downloadedFile) throws PluginException {
+        try {
+            if (Files.isRegularFile(downloadedFile) && Files.size(downloadedFile) > 0) {
+                return;
+            }
+        } catch (IOException e) { /* Fallthrough */ }
+        throw new PluginException("Failed downloading file " + downloadedFile);
+    }
 }

--- a/src/main/java/ro/fortsoft/pf4j/update/SimpleFileDownloader.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/SimpleFileDownloader.java
@@ -86,7 +86,8 @@ public class SimpleFileDownloader implements FileDownloader {
      * Downloads file from HTTP or FTP
      * @param fileUrl source file
      * @return path of downloaded file
-     * @throws IOException if problems
+     * @throws IOException if IO problems
+     * @throws PluginException if validation fails or any other problems
      */
     protected Path downloadFileHttp(URL fileUrl) throws IOException, PluginException {
         Path destination = Files.createTempDirectory("pf4j-update-downloader");
@@ -143,7 +144,7 @@ public class SimpleFileDownloader implements FileDownloader {
     }
 
     /**
-     * Succeeds if downloaded file exists and has size > 0
+     * Succeeds if downloaded file exists and has size &gt; 0
      * <p>Override this method to provide your own validation rules such as content length matching or checksum checking etc</p>
      * @param originalUrl the source from which the file was downloaded
      * @param downloadedFile the path to the downloaded file


### PR DESCRIPTION
Thought of adding validation of `Content-Length` header too, but some servers may not return it, so that can be left up to custom implementations.