### PR TITLE
Change name of the getLocation method to a simple getUrl

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1,5 +1,6 @@
 [
   {
+    "pluginsJsonFileName": "plugins.json",
     "id": "localhost",
     "url": "http://localhost:8081/"
   }

--- a/src/main/java/ro/fortsoft/pf4j/update/DefaultUpdateRepository.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/DefaultUpdateRepository.java
@@ -51,7 +51,7 @@ public class DefaultUpdateRepository implements UpdateRepository {
     }
 
     @Override
-    public String getLocation() {
+    public String getUrl() {
         return url;
     }
 

--- a/src/main/java/ro/fortsoft/pf4j/update/DefaultUpdateRepository.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/DefaultUpdateRepository.java
@@ -35,31 +35,30 @@ public class DefaultUpdateRepository implements UpdateRepository {
     private String pluginsJsonFileName = "plugins.json";
 
     private String id;
-    private String url;
+    private URL url;
     private Map<String, PluginInfo> plugins;
 
-    public DefaultUpdateRepository(String id, String url) {
+    public DefaultUpdateRepository(String id, URL url) {
         this.id = id;
-        if (!url.endsWith("/")) {
-            url += "/";
-        }
         this.url = url;
     }
 
-    public DefaultUpdateRepository(String id, String url, String pluginsJsonFileName) {
+    public DefaultUpdateRepository(String id, URL url, String pluginsJsonFileName) {
         this(id, url);
         this.pluginsJsonFileName = pluginsJsonFileName;
     }
 
+    @Override
     public String getId() {
         return id;
     }
 
     @Override
-    public String getUrl() {
+    public URL getUrl() {
         return url;
     }
 
+    @Override
     public Map<String, PluginInfo> getPlugins() {
         if (plugins == null) {
             initPlugins();
@@ -68,6 +67,7 @@ public class DefaultUpdateRepository implements UpdateRepository {
         return plugins;
     }
 
+    @Override
     public PluginInfo getPlugin(String id) {
         return getPlugins().get(id);
     }
@@ -75,7 +75,7 @@ public class DefaultUpdateRepository implements UpdateRepository {
     private void initPlugins() {
         Reader pluginsJsonReader;
         try {
-            URL pluginsUrl = new URL(new URL(url), pluginsJsonFileName);
+            URL pluginsUrl = new URL(url, pluginsJsonFileName);
             log.debug("Read plugins of '{}' repository from '{}'", id, pluginsUrl);
             pluginsJsonReader = new InputStreamReader(pluginsUrl.openStream());
         } catch (Exception e) {
@@ -90,7 +90,7 @@ public class DefaultUpdateRepository implements UpdateRepository {
         for (PluginInfo p : items) {
             for (PluginRelease r : p.releases) {
                 try {
-                    r.url = new URL(new URL(url), r.url).toString();
+                    r.url = new URL(url, r.url).toString();
                 } catch (MalformedURLException e) {
                     log.warn("Skipping release {} of plugin {} due to failure to build valid absolute URL. Url was {}{}", r.version, p.id, url, r.url);
                 }
@@ -103,6 +103,7 @@ public class DefaultUpdateRepository implements UpdateRepository {
     /**
      * Causes plugins.json to be read again to look for new updates from repos
      */
+    @Override
     public void refresh() {
         plugins = null;
     }

--- a/src/main/java/ro/fortsoft/pf4j/update/DefaultUpdateRepository.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/DefaultUpdateRepository.java
@@ -75,7 +75,7 @@ public class DefaultUpdateRepository implements UpdateRepository {
     private void initPlugins() {
         Reader pluginsJsonReader;
         try {
-            URL pluginsUrl = new URL(url, pluginsJsonFileName);
+            URL pluginsUrl = new URL(getUrl(), pluginsJsonFileName);
             log.debug("Read plugins of '{}' repository from '{}'", id, pluginsUrl);
             pluginsJsonReader = new InputStreamReader(pluginsUrl.openStream());
         } catch (Exception e) {
@@ -90,9 +90,9 @@ public class DefaultUpdateRepository implements UpdateRepository {
         for (PluginInfo p : items) {
             for (PluginRelease r : p.releases) {
                 try {
-                    r.url = new URL(url, r.url).toString();
+                    r.url = new URL(getUrl(), r.url).toString();
                 } catch (MalformedURLException e) {
-                    log.warn("Skipping release {} of plugin {} due to failure to build valid absolute URL. Url was {}{}", r.version, p.id, url, r.url);
+                    log.warn("Skipping release {} of plugin {} due to failure to build valid absolute URL. Url was {}{}", r.version, p.id, getUrl(), r.url);
                 }
             }
             plugins.put(p.id, p);

--- a/src/main/java/ro/fortsoft/pf4j/update/FileDownloader.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/FileDownloader.java
@@ -29,10 +29,10 @@ public interface FileDownloader {
      * Downloads a file to destination. The implementation should download to a temporary folder.
      * Implementations may choose to support different protocols such as http, https, ftp, file...
      * The path returned must be of temporary nature and will most probably be moved/deleted by consumer
-     * @param fileUrl the URI representing the file to download
+     * @param fileUrl the URL representing the file to download
      * @return Path of downloaded file, typically in a temporary folder
      * @throws IOException if there was an IO problem during download
      * @throws PluginException in case of other problems, such as unsupported protocol
      */
-    public Path downloadFile(URL fileUrl) throws PluginException, IOException;
+    Path downloadFile(URL fileUrl) throws PluginException, IOException;
 }

--- a/src/main/java/ro/fortsoft/pf4j/update/UpdateManager.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/UpdateManager.java
@@ -153,7 +153,7 @@ public class UpdateManager {
      * @param id of repo
      * @param url of repo
      */
-    public void addRepository(String id, String url) {
+    public void addRepository(String id, URL url) {
         for (UpdateRepository ur : repositories) {
             if (ur.getId().equals(id)) {
                 throw new RuntimeException("Repository with id " + id + " already exists");
@@ -200,31 +200,6 @@ public class UpdateManager {
         for (UpdateRepository updateRepository : repositories) {
             updateRepository.refresh();
         }
-    }
-
-    /**
-     * Installs a plugin given only its URL
-     * @param url the url of the plugin to install
-     * @return true if plugin was installed
-     * @deprecated - use the installPlugin(id, version) instead
-     */
-    public boolean installPlugin(String url) {
-        FileDownloader downloader = new SimpleFileDownloader();
-        try {
-            Path downloaded = downloader.downloadFile(new URL(url));
-
-            Path pluginsRoot = pluginManager.getPluginsRoot();
-            Path file = pluginsRoot.resolve(downloaded.getFileName());
-            Files.move(downloaded, file);
-
-            String newPluginId = pluginManager.loadPlugin(file);
-            PluginState state = pluginManager.startPlugin(newPluginId);
-
-            return PluginState.STARTED.equals(state);
-        } catch (Exception e) {
-            log.error("Plugin at " + url + " not installed.", e);
-        }
-        return false;
     }
 
     /**
@@ -308,10 +283,10 @@ public class UpdateManager {
         throw new PluginException("Plugin " + id + " with version @" + version + " does not exist in the repository");
     }
 
-    public boolean updatePlugin(String id, String url) {
+    public boolean updatePlugin(String id, URL url) {
         try {
             // Download to temp folder
-            Path downloaded = getFileDownloader(id).downloadFile(new URL(url));
+            Path downloaded = getFileDownloader(id).downloadFile(url);
 
             if (!pluginManager.deletePlugin(id)) {
                 return false;

--- a/src/main/java/ro/fortsoft/pf4j/update/UpdateRepository.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/UpdateRepository.java
@@ -27,9 +27,9 @@ public interface UpdateRepository {
     public String getId();
 
     /**
-     * @return the location of this repo as a String. Typically a URL
+     * @return the URL of this repo as a String
      */
-    public String getLocation();
+    public String getUrl();
 
     /**
      * Get all plugin descriptors for this repo

--- a/src/main/java/ro/fortsoft/pf4j/update/UpdateRepository.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/UpdateRepository.java
@@ -15,6 +15,7 @@
  */
 package ro.fortsoft.pf4j.update;
 
+import java.net.URL;
 import java.util.Map;
 
 /**
@@ -29,7 +30,7 @@ public interface UpdateRepository {
     /**
      * @return the URL of this repo as a String
      */
-    public String getUrl();
+    public URL getUrl();
 
     /**
      * Get all plugin descriptors for this repo

--- a/src/test/java/ro/fortsoft/pf4j/update/InstallAndDownloadTest.java
+++ b/src/test/java/ro/fortsoft/pf4j/update/InstallAndDownloadTest.java
@@ -28,6 +28,7 @@ import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.*;
 import java.util.*;
@@ -47,7 +48,7 @@ public class InstallAndDownloadTest {
     private PluginManager pluginManager;
     private UpdateManager updateManager;
     private Version systemVersion;
-    private String repoUrl;
+    private URL repoUrl;
     private List<PluginWrapper> installed;
 
     @Before
@@ -67,7 +68,7 @@ public class InstallAndDownloadTest {
         String jsonForPlugins = getJsonForPlugins(p1,p2,p3,p4);
         writer.write(jsonForPlugins);
         writer.close();
-        repoUrl = "file:" + downloadRepoDir.toAbsolutePath().toString() + "/";
+        repoUrl = new URL("file:" + downloadRepoDir.toAbsolutePath().toString() + "/");
         UpdateRepository local = new DefaultUpdateRepository("local", repoUrl);
         p1.create();
         p2.create();
@@ -100,7 +101,7 @@ public class InstallAndDownloadTest {
         assertTrue(updateManager.installPlugin("myPlugin", "1.2.3"));
         assertTrue(updateManager.hasUpdates());
         assertEquals(1, updateManager.getUpdates().size());
-        String p2url = updateManager.getUpdates().get(0).getLastRelease(systemVersion).url;
+        URL p2url = new URL(updateManager.getUpdates().get(0).getLastRelease(systemVersion).url);
         assertTrue(updateManager.updatePlugin("myPlugin", p2url));
         assertTrue(Files.exists(pluginFolderDir.resolve(p2.zipname)));
         assertTrue(Files.exists(pluginFolderDir.resolve(p2.pluginRepoUnzippedFolder)));

--- a/src/test/java/ro/fortsoft/pf4j/update/RepositoriesTest.java
+++ b/src/test/java/ro/fortsoft/pf4j/update/RepositoriesTest.java
@@ -20,6 +20,8 @@ import com.google.gson.GsonBuilder;
 
 import java.io.FileWriter;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,7 +32,7 @@ public class RepositoriesTest {
 
     private static final String repositoriesFile = "repositories.json";
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         FileWriter writer;
         try {
             writer = new FileWriter(repositoriesFile);
@@ -42,7 +44,7 @@ public class RepositoriesTest {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         List<UpdateRepository> repositories = new ArrayList<UpdateRepository>();
 //        repositories.add(new UpdateRepository("local", "file:/home/decebal_suiu/work/pf4j-update/plugins/"));
-        repositories.add(new DefaultUpdateRepository("localhost", "http://localhost:8081/"));
+        repositories.add(new DefaultUpdateRepository("localhost", new URL("http://localhost:8081/")));
 //        repositories.add(new UpdateRepository("localhost2", "http://localhost:8088/"));
 //        repositories.add(new UpdateRepository("localhost3", "http://localhost:8888/"));
 

--- a/src/test/java/ro/fortsoft/pf4j/update/UpdateTest.java
+++ b/src/test/java/ro/fortsoft/pf4j/update/UpdateTest.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import ro.fortsoft.pf4j.DefaultPluginManager;
 import ro.fortsoft.pf4j.PluginManager;
 
+import java.net.URL;
 import java.util.List;
 
 /**
@@ -30,14 +31,12 @@ public class UpdateTest {
 
     private static final Logger log = LoggerFactory.getLogger(UpdateTest.class);
 
-    private static final String repositoriesFile = "repositories.json";
-
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
 //        createTestRepositories();
         update();
     }
 
-    private static void update() {
+    private static void update() throws Exception {
         // start the web server that serves the repository's artifacts
         try {
             new WebServer().start();
@@ -67,7 +66,7 @@ public class UpdateTest {
                 String lastVersion = lastRelease.version;
                 String installedVersion = pluginManager.getPlugin(plugin.id).getDescriptor().getVersion().toString();
                 log.debug("Update plugin '{}' from version {} to version {}", plugin.id, installedVersion, lastVersion);
-                boolean updated = updateManager.updatePlugin(plugin.id, lastRelease.url);
+                boolean updated = updateManager.updatePlugin(plugin.id, new URL(lastRelease.url));
                 if (updated) {
                     log.debug("Updated plugin '{}'", plugin.id);
                 } else {
@@ -88,7 +87,7 @@ public class UpdateTest {
                 PluginInfo.PluginRelease lastRelease = plugin.getLastRelease(systemVersion);
                 String lastVersion = lastRelease.version;
                 log.debug("Install plugin '{}' with version {}", plugin.id, lastVersion);
-                boolean installed = updateManager.installPlugin(lastRelease.url);
+                boolean installed = updateManager.installPlugin(plugin.id, lastVersion);
                 if (installed) {
                     log.debug("Installed plugin '{}'", plugin.id);
                 } else {


### PR DESCRIPTION
This method is not yet released in any releases, so it should be safe to rename it. The new name better reflects what it returns, and users will know that it is always a URL being returned.