### PR TITLE
Changes updatePlugin signature to id,version

### DIFF
--- a/src/test/java/ro/fortsoft/pf4j/update/InstallAndDownloadTest.java
+++ b/src/test/java/ro/fortsoft/pf4j/update/InstallAndDownloadTest.java
@@ -19,6 +19,7 @@ import com.github.zafarkhaja.semver.Version;
 import com.google.gson.GsonBuilder;
 import org.junit.Before;
 import org.junit.Test;
+import ro.fortsoft.pf4j.PluginException;
 import ro.fortsoft.pf4j.PluginManager;
 import ro.fortsoft.pf4j.PluginWrapper;
 import ro.fortsoft.pf4j.update.util.PropertiesPluginManager;
@@ -101,12 +102,23 @@ public class InstallAndDownloadTest {
         assertTrue(updateManager.installPlugin("myPlugin", "1.2.3"));
         assertTrue(updateManager.hasUpdates());
         assertEquals(1, updateManager.getUpdates().size());
-        URL p2url = new URL(updateManager.getUpdates().get(0).getLastRelease(systemVersion).url);
-        assertTrue(updateManager.updatePlugin("myPlugin", p2url));
+        assertTrue(updateManager.updatePlugin("myPlugin", null)); // latest release
         assertTrue(Files.exists(pluginFolderDir.resolve(p2.zipname)));
         assertTrue(Files.exists(pluginFolderDir.resolve(p2.pluginRepoUnzippedFolder)));
         assertFalse(Files.exists(pluginFolderDir.resolve(p1.zipname)));
         assertFalse(Files.exists(pluginFolderDir.resolve(p1.pluginRepoUnzippedFolder)));
+    }
+
+    @Test(expected = PluginException.class)
+    public void updateVersionNotexist() throws Exception {
+        assertTrue(updateManager.installPlugin("myPlugin", "1.2.3"));
+        updateManager.updatePlugin("myPlugin", "9.9.9");
+    }
+
+    @Test
+    public void noUpdateAvailable() throws Exception {
+        assertTrue(updateManager.installPlugin("myPlugin", null)); // Install latest
+        assertFalse(updateManager.updatePlugin("myPlugin", null)); // Update to latest
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/ro/fortsoft/pf4j/update/UpdateTest.java
+++ b/src/test/java/ro/fortsoft/pf4j/update/UpdateTest.java
@@ -21,7 +21,6 @@ import org.slf4j.LoggerFactory;
 import ro.fortsoft.pf4j.DefaultPluginManager;
 import ro.fortsoft.pf4j.PluginManager;
 
-import java.net.URL;
 import java.util.List;
 
 /**
@@ -66,7 +65,7 @@ public class UpdateTest {
                 String lastVersion = lastRelease.version;
                 String installedVersion = pluginManager.getPlugin(plugin.id).getDescriptor().getVersion().toString();
                 log.debug("Update plugin '{}' from version {} to version {}", plugin.id, installedVersion, lastVersion);
-                boolean updated = updateManager.updatePlugin(plugin.id, new URL(lastRelease.url));
+                boolean updated = updateManager.updatePlugin(plugin.id, lastVersion);
                 if (updated) {
                     log.debug("Updated plugin '{}'", plugin.id);
                 } else {


### PR DESCRIPTION
This is a followup from #18 

Adds PluginException to both updatePlugin and installPlugin for better error flow. The client can write code, loops etc without null-checks such as `if (!installPlugin(foo,"1.0.0")) ...` but instead get a problem description in the exception that could also be displayed in a GUI. Now you only get a true/false and must check logs to see why the install/update failed. What do you think?

Also adds support for installing/updating to latest version by setting version=null.