### PR TITLE
Add repositoryId to PluginInfo

### DIFF
--- a/src/main/java/ro/fortsoft/pf4j/update/DefaultUpdateRepository.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/DefaultUpdateRepository.java
@@ -95,6 +95,7 @@ public class DefaultUpdateRepository implements UpdateRepository {
                     log.warn("Skipping release {} of plugin {} due to failure to build valid absolute URL. Url was {}{}", r.version, p.id, getUrl(), r.url);
                 }
             }
+            p.setRepositoryId(getId());
             plugins.put(p.id, p);
         }
         log.debug("Found {} plugins in repository '{}'", plugins.size(), id);

--- a/src/main/java/ro/fortsoft/pf4j/update/PluginInfo.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/PluginInfo.java
@@ -40,6 +40,9 @@ public class PluginInfo implements Serializable, Comparable<PluginInfo> {
     public String projectUrl;
     public List<PluginRelease> releases;
 
+    // This is metadata added at parse time, not part of the published plugins.json
+    private String repositoryId;
+
     // Cache lastRelease per system version
     private Map<Version, PluginRelease> lastRelease = new HashMap<>();
 
@@ -67,7 +70,7 @@ public class PluginInfo implements Serializable, Comparable<PluginInfo> {
     }
 
     /**
-     * Finds whether the repo has a newer version of the plugin
+     * Finds whether the  newer version of the plugin
      * @param systemVersion version of host system where plugin will be installed
      * @param installedVersion version that is already installed
      * @return true if there is a newer version available which is compatible with system
@@ -80,6 +83,14 @@ public class PluginInfo implements Serializable, Comparable<PluginInfo> {
     @Override
     public int compareTo(PluginInfo o) {
         return id.compareTo(o.id);
+    }
+
+    public String getRepositoryId() {
+        return repositoryId;
+    }
+
+    public void setRepositoryId(String repositoryId) {
+        this.repositoryId = repositoryId;
     }
 
     public static class PluginRelease implements Serializable, Comparable<PluginRelease> {

--- a/src/test/java/ro/fortsoft/pf4j/update/InstallAndDownloadTest.java
+++ b/src/test/java/ro/fortsoft/pf4j/update/InstallAndDownloadTest.java
@@ -132,6 +132,13 @@ public class InstallAndDownloadTest {
         assertTrue(updateManager.uninstallPlugin("other"));
     }
 
+    @Test
+    public void repositoryIdIsFilled() throws Exception {
+        for (PluginInfo info : updateManager.getAvailablePlugins()) {
+            assertEquals("local", info.getRepositoryId());
+        }
+    }
+
     // ****************** MOCK *********************
 
     private class MockZipPlugin {


### PR DESCRIPTION
This is not part of the plugininfo.json but metadata to bind the pluginId to repositoryId
That way a client application can get list of available plugins across all repos, and be able to retrieve repositoryId for each of them.