### PR TITLE
Lenient parsing of release date in descriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Below I registered two plugins: _welcome-plugin_ and _hello-plugin_.
 |Property    |Format       |Description                        |
 |------------|-------------|-----------------------------------|
 |version     |X.Y.Z        |Version of release ([SemVer](http://semver.org/) format) |
-|date        |date         |Release date, parsable format      |
+|date        |date         |Release date, ISO8601 or `yyyy-MM-dd` format |
 |requires    |Expression   |[SemVer expression](https://github.com/zafarkhaja/jsemver#semver-expressions-api-ranges), e.g. ">=2.0.0"  |
 |url         |URL-string   |Link to zip, either absolute or relative URL |
 
@@ -201,6 +201,10 @@ Below I registered two plugins: _welcome-plugin_ and _hello-plugin_.
 The last (current) release of the plugin is calculated taking into account
 by the _version_ property. In our example, the last release for each
 plugin is the release with version _0.9.0_.
+
+We encourage using `yyyy-MM-dd` format for release date. Localized US format
+as in the examples above will also work. If the date is not parsable, it
+will be set to epoch (1970-01-01) and print a warning in logs.
 
 **NOTE**: The `requires` property was a simple X.Y.Z string in versions
 up to 0.3.0, interpreted as `>=X.Y.Z`. You may want to update your old

--- a/src/main/java/ro/fortsoft/pf4j/update/DefaultUpdateRepository.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/DefaultUpdateRepository.java
@@ -16,19 +16,13 @@
 package ro.fortsoft.pf4j.update;
 
 import com.google.gson.*;
-import com.google.gson.reflect.TypeToken;
-import com.google.gson.stream.JsonReader;
-import com.google.gson.stream.JsonToken;
-import com.google.gson.stream.JsonWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ro.fortsoft.pf4j.update.PluginInfo.PluginRelease;
+import ro.fortsoft.pf4j.update.util.LenientDateTypeAdapter;
 
 import java.io.*;
 import java.net.*;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.*;
 
 /**
@@ -133,72 +127,6 @@ public class DefaultUpdateRepository implements UpdateRepository {
      */
     public void setPluginsJsonFileName(String pluginsJsonFileName) {
         this.pluginsJsonFileName = pluginsJsonFileName;
-    }
-
-    /* Fork of com.google.gson.internal.bind.DateTypeAdapter */
-    private static class LenientDateTypeAdapter extends TypeAdapter<Date> {
-        public static final TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
-          @SuppressWarnings("unchecked") // we use a runtime check to make sure the 'T's equal
-          public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
-            return typeToken.getRawType() == Date.class ? (TypeAdapter<T>) new LenientDateTypeAdapter() : null;
-          }
-        };
-
-        private final DateFormat enUsFormat
-            = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT, Locale.US);
-        private final DateFormat localFormat
-            = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT);
-        private final DateFormat iso8601Format = buildIso8601Format();
-        private final DateFormat shortFormat = buildShortFormat();
-
-        private static DateFormat buildIso8601Format() {
-          DateFormat iso8601Format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
-          iso8601Format.setTimeZone(TimeZone.getTimeZone("UTC"));
-          return iso8601Format;
-        }
-
-        private static DateFormat buildShortFormat() {
-          DateFormat shortFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.ROOT);
-          shortFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-          return shortFormat;
-        }
-
-        @Override public Date read(JsonReader in) throws IOException {
-          if (in.peek() == JsonToken.NULL) {
-            in.nextNull();
-            return null;
-          }
-          return deserializeToDate(in.nextString());
-        }
-
-        private synchronized Date deserializeToDate(String json) {
-          try {
-            return localFormat.parse(json);
-          } catch (ParseException ignored) {
-          }
-          try {
-            return enUsFormat.parse(json);
-          } catch (ParseException ignored) {
-          }
-          try {
-            return iso8601Format.parse(json);
-          } catch (ParseException ignored) {
-          }
-          try {
-            return shortFormat.parse(json);
-          } catch (ParseException e) {
-            return new Date(0);
-          }
-        }
-
-        @Override public synchronized void write(JsonWriter out, Date value) throws IOException {
-          if (value == null) {
-            out.nullValue();
-            return;
-          }
-          String dateFormatAsString = enUsFormat.format(value);
-          out.value(dateFormatAsString);
-        }
     }
 
 }

--- a/src/main/java/ro/fortsoft/pf4j/update/util/LenientDateTypeAdapter.java
+++ b/src/main/java/ro/fortsoft/pf4j/update/util/LenientDateTypeAdapter.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2011 Google Inc
+ * Copyright 2017 Decebal Suiu (this fork)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.fortsoft.pf4j.update.util;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+/**
+ * Fork of com.google.gson.internal.bind.DateTypeAdapter
+ */
+public class LenientDateTypeAdapter extends TypeAdapter<Date> {
+    public static final TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
+        @SuppressWarnings("unchecked") // we use a runtime check to make sure the 'T's equal
+        public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
+            return typeToken.getRawType() == Date.class ? (TypeAdapter<T>) new LenientDateTypeAdapter() : null;
+        }
+    };
+
+    private final DateFormat enUsFormat
+            = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT, Locale.US);
+    private final DateFormat localFormat
+            = DateFormat.getDateTimeInstance(DateFormat.DEFAULT, DateFormat.DEFAULT);
+    private final DateFormat iso8601Format = buildIso8601Format();
+    private final DateFormat shortFormat = buildShortFormat();
+
+    private static DateFormat buildIso8601Format() {
+        DateFormat iso8601Format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
+        iso8601Format.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return iso8601Format;
+    }
+
+    private static DateFormat buildShortFormat() {
+        DateFormat shortFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.ROOT);
+        shortFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return shortFormat;
+    }
+
+    @Override
+    public Date read(JsonReader in) throws IOException {
+        if (in.peek() == JsonToken.NULL) {
+            in.nextNull();
+            return null;
+        }
+        return deserializeToDate(in.nextString());
+    }
+
+    private synchronized Date deserializeToDate(String json) {
+        try {
+            return localFormat.parse(json);
+        } catch (ParseException ignored) {
+        }
+        try {
+            return enUsFormat.parse(json);
+        } catch (ParseException ignored) {
+        }
+        try {
+            return iso8601Format.parse(json);
+        } catch (ParseException ignored) {
+        }
+        try {
+            return shortFormat.parse(json);
+        } catch (ParseException e) {
+            return new Date(0);
+        }
+    }
+
+    @Override
+    public synchronized void write(JsonWriter out, Date value) throws IOException {
+        if (value == null) {
+            out.nullValue();
+            return;
+        }
+        String dateFormatAsString = enUsFormat.format(value);
+        out.value(dateFormatAsString);
+    }
+}


### PR DESCRIPTION
Now accepts local date, full ISO as well as date-only YYYY-mm-dd
If date is still unparsable, don't throw exception, but set to 0 (epoch) and print warning in logs
Fixes #20